### PR TITLE
Univention Config Registry: manually read registry files

### DIFF
--- a/plugins/modules/univention_config_registry.py
+++ b/plugins/modules/univention_config_registry.py
@@ -133,11 +133,11 @@ def _commit_files(files, result, module):
     result['changed'] = len(files) > 0
 
     if not result['changed']:
-        result['message'] = "No files need to be unset"
+        result['message'] = "No files need to be committed"
 
     if module.check_mode:
         if len(files) > 0:
-            result['message'] = "These files will be commited: {}".format(" ".join(files))
+            result['message'] = "These files will be committed: {}".format(" ".join(files))
         return
 
     if not result['changed']:
@@ -156,7 +156,7 @@ def _commit_files(files, result, module):
     result['err'] = err.rstrip("\r\n")
     result['rc'] = rc
     result['meta']['commited_templates'] = files
-    result['message'] = "These files were be commited: {}".format(" ".join(files))
+    result['message'] = "These files were committed: {}".format(" ".join(files))
     result['failed'] = rc != 0 or len(err) > 0
 
     if rc != 0:


### PR DESCRIPTION
So far Univention's own config registry backend module was loaded & its functionality used for reading the UCR. This is
unfortunately incompatible with using the Mitogen connection strategy plugin & Python 3. See [this bug report](https://github.com/mitogen-hq/mitogen/issues/904) for more details.

My understanding is that Mitogen works by streaming Python modules from the Ansible host to the target machine, meaning the imported modules must exist on the host machine, too, which would limit the Ansible host to being a Univention system, too.

Interestingly this only manifests when Python 3 is used as the Python interpreter on the target; it works fine with Python 2. The reason is unclear.

This PR converts using Univention's own backend modules to reading the files directly/using `ucr commit` for committing files.

The other commit solely fixes three spelling mistakes.